### PR TITLE
Add width and height field into images_messages

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -219,6 +219,14 @@ components:
                     type: string
                     description: 画像URL
                     example: https://
+                  width:
+                    type: integer
+                    description: 画像の幅(px)
+                    example: 1200
+                  height:
+                    type: integer
+                    description: 画像の高さ(px)
+                    example: 600
                   sender_name:
                     type: string
                     description: 送信者
@@ -324,6 +332,14 @@ components:
                 type: string
                 description: 画像のURL
                 example: https://
+              width:
+                type: integer
+                description: 画像の幅(px)
+                example: 1200
+              height:
+                type: integer
+                description: 画像の高さ(px)
+                example: 600
               sender_name:
                 type: string
                 description: 送信者


### PR DESCRIPTION
# Overview <!-- What is the change -->
閲覧面で使いたいのでアップロードした画像の width/height をそれぞれ取得できるようにしたい 🙏 



# Issue number <!-- e.g. Close #123, Fix #456 -->
Close #


# How to check the revision
1. 

# Points for Review <!-- Things you want reviewers to check, etc. -->


# Remarks <!-- Any other comments -->


<!-- You don't have to fill in all the blanks, but write the necessary information clearly. -->